### PR TITLE
fix: parse sort arguments for company/status/date and reverse (#201)

### DIFF
--- a/src/main/java/app/CommandRunner.java
+++ b/src/main/java/app/CommandRunner.java
@@ -171,7 +171,7 @@ public class CommandRunner {
             applications.sort(comparator);
         }
 
-        Ui.showSortedMessage();
+        Ui.showSortedMessage(sortType);
         Ui.showApplicationList(applications);
     }
 

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -51,11 +51,17 @@ public class Parser {
                 }
                 return new ParsedCommand(CommandType.LIST);
 
-            case "sort":
-                if (!isLoneCommand(trimmed, "sort")) {
-                    return rejectExtraArgs("sort");
+            case "sort": {
+                String[] sortParts = trimmed.split("\\s+", 2);
+                if (sortParts.length == 1) {
+                    return new ParsedCommand(CommandType.SORT);
                 }
-                return new ParsedCommand(CommandType.SORT);
+                String sortArgs = sortParts[1].trim();
+                if (sortArgs.isEmpty()) {
+                    return new ParsedCommand(CommandType.SORT);
+                }
+                return new ParsedCommand(CommandType.SORT, sortArgs);
+            }
 
             case "help":
                 if (!isLoneCommand(trimmed, "help")) {

--- a/src/main/java/ui/Ui.java
+++ b/src/main/java/ui/Ui.java
@@ -156,10 +156,25 @@ public class Ui {
     }
 
     /**
-     * Displays a message indicating that applications have been sorted.
+     * Displays a message indicating how applications were sorted.
+     *
+     * @param sortSpec trimmed lowercased sort specification (e.g. {@code ""}, {@code "date reverse"},
+     *                 {@code "company"})
      */
-    public static void showSortedMessage() {
-        System.out.println("Sorted by submission date!");
+    public static void showSortedMessage(String sortSpec) {
+        String s = sortSpec != null ? sortSpec.trim().toLowerCase() : "";
+        boolean rev = s.contains("reverse");
+        String key = s.replace("reverse", "").trim();
+        String field;
+        if (key.startsWith("company")) {
+            field = "company name";
+        } else if (key.startsWith("status")) {
+            field = "status";
+        } else {
+            field = "submission date";
+        }
+        String order = rev ? " (reverse order)." : ".";
+        System.out.println("Sorted by " + field + order);
     }
 
     /**

--- a/src/test/java/task/SortTest.java
+++ b/src/test/java/task/SortTest.java
@@ -43,4 +43,19 @@ public class SortTest {
 
         assertEquals(app1, applications.get(0));
     }
+
+    @Test
+    void sortApplications_sortByCompany_ordersAlphabetically() {
+        Application app1 = new Application("Zebra", "Role", "2025-01-01");
+        Application app2 = new Application("Apple", "Role", "2025-02-01");
+
+        applications.add(app1);
+        applications.add(app2);
+
+        ParsedCommand cmd = new ParsedCommand(CommandType.SORT, "company");
+        runner.run(cmd);
+
+        assertEquals(app2, applications.get(0));
+        assertEquals(app1, applications.get(1));
+    }
 }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -63,7 +63,7 @@ ___________________________________________________________________
 Found 1 application(s) matching 's/offer':
 1. Google | SE manager | 2025-03-10 | OFFER (Note: Negotiate salary) | Tags: [TECH]
 ___________________________________________________________________
-Sorted by submission date!
+Sorted by submission date.
 Here are your applications:
 1. Amazon | Data Analyst | 2025-03-08 | INTERVIEW (Note: Case study prep) | Tags: [FINANCE, DATA]
 2. Google | SE manager | 2025-03-10 | OFFER (Note: Negotiate salary) | Tags: [TECH]


### PR DESCRIPTION
Fixes #201
Fixes #219
Fixes #202
Fixes #165

- Parser: allow sort with trailing spec instead of rejecting as extra args.

- Ui: sort confirmation matches field and reverse.

- SortTest: cover sort company; text-ui-test expected line updated.
