### PR TITLE
test+refactor: strengthen sort coverage and simplify tag handling

### DIFF
--- a/src/main/java/app/CommandRunner.java
+++ b/src/main/java/app/CommandRunner.java
@@ -289,20 +289,16 @@ public class CommandRunner {
 
         Application target = applications.get(idx);
 
-        try {
-            if (cmd.isAddTag()) {
-                if (target.addIndustryTag(cmd.getTag())) {
-                    Ui.showTagAdded(cmd.getTag(), target);
-                } else {
-                    Ui.showError("This application already has that tag.");
-                }
-            } else if (target.removeIndustryTag(cmd.getTag())) {
-                Ui.showTagRemoved(cmd.getTag(), target);
+        if (cmd.isAddTag()) {
+            if (target.addIndustryTag(cmd.getTag())) {
+                Ui.showTagAdded(cmd.getTag(), target);
             } else {
-                Ui.showError("Tag not found on this application!");
+                Ui.showError("This application already has that tag.");
             }
-        } catch (Exception e) {
-            Ui.showError(e.getMessage());
+        } else if (target.removeIndustryTag(cmd.getTag())) {
+            Ui.showTagRemoved(cmd.getTag(), target);
+        } else {
+            Ui.showError("Tag not found on this application!");
         }
     }
 

--- a/src/test/java/task/SortTest.java
+++ b/src/test/java/task/SortTest.java
@@ -100,4 +100,41 @@ public class SortTest {
         assertEquals(app1, applications.get(0));
         assertEquals(app2, applications.get(1));
     }
+
+    @Test
+    void sortApplications_sortByCompanyReverse_ordersDescendingAlphabetically() {
+        Application app1 = new Application("Apple", "Role", "2025-01-01");
+        Application app2 = new Application("Zebra", "Role", "2025-02-01");
+        Application app3 = new Application("Microsoft", "Role", "2025-03-01");
+        applications.add(app1);
+        applications.add(app2);
+        applications.add(app3);
+
+        ParsedCommand cmd = new ParsedCommand(CommandType.SORT, "company reverse");
+        runner.run(cmd);
+
+        assertEquals(app2, applications.get(0));
+        assertEquals(app3, applications.get(1));
+        assertEquals(app1, applications.get(2));
+    }
+
+    @Test
+    void sortApplications_sortByStatusReverse_ordersDescendingByStatus() {
+        Application app1 = new Application("Apple", "Role", "2025-01-01");
+        Application app2 = new Application("Zebra", "Role", "2025-02-01");
+        Application app3 = new Application("Microsoft", "Role", "2025-03-01");
+        app1.setStatus("PENDING");
+        app2.setStatus("INTERVIEW");
+        app3.setStatus("OFFER");
+        applications.add(app1);
+        applications.add(app2);
+        applications.add(app3);
+
+        ParsedCommand cmd = new ParsedCommand(CommandType.SORT, "status reverse");
+        runner.run(cmd);
+
+        assertEquals(app1, applications.get(0));
+        assertEquals(app3, applications.get(1));
+        assertEquals(app2, applications.get(2));
+    }
 }


### PR DESCRIPTION
fixes #276

- Add reverse-order tests for company and status sorting.

- Remove broad catch(Exception) in tag handler and keep explicit result-based errors.
