### PR TITLE
fix: reject multi-prefix search input

### DIFF
--- a/src/main/java/parser/subparsers/SearcherParser.java
+++ b/src/main/java/parser/subparsers/SearcherParser.java
@@ -8,6 +8,8 @@ import parser.ParsedCommand;
  * Supports one field prefix (c/p/s) with case-insensitive partial matching.
  */
 public class SearcherParser {
+    private static final String SEARCH_MULTI_PREFIX_ERROR =
+            "Search supports one prefix per command only. Use: search c/xxx or p/xxx or s/xxx";
 
     public static ParsedCommand parse(String input) throws JobPilotException {
         if (input == null || input.trim().isEmpty()) {
@@ -28,6 +30,9 @@ public class SearcherParser {
 
         String type = args.substring(0, slashIndex).trim().toLowerCase();
         String value = args.substring(slashIndex + 1).trim().toLowerCase();
+        if (containsAnotherPrefix(value)) {
+            throw new JobPilotException(SEARCH_MULTI_PREFIX_ERROR);
+        }
 
         if (value.isEmpty()) {
             throw new JobPilotException("Search value cannot be empty!");
@@ -38,5 +43,9 @@ public class SearcherParser {
         }
 
         return new ParsedCommand(type, value);
+    }
+
+    private static boolean containsAnotherPrefix(String value) {
+        return value.contains(" c/") || value.contains(" p/") || value.contains(" s/");
     }
 }

--- a/src/test/java/parser/subparsers/SearcherParserTest.java
+++ b/src/test/java/parser/subparsers/SearcherParserTest.java
@@ -1,0 +1,30 @@
+package parser.subparsers;
+
+import exception.JobPilotException;
+import org.junit.jupiter.api.Test;
+import parser.ParsedCommand;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SearcherParserTest {
+
+    @Test
+    void parse_validSinglePrefix_success() throws JobPilotException {
+        ParsedCommand cmd = SearcherParser.parse("search c/google");
+        assertEquals("c", cmd.getSearchType());
+        assertEquals("google", cmd.getSearchTerm());
+    }
+
+    @Test
+    void parse_multiplePrefixes_throws() {
+        assertThrows(JobPilotException.class, () ->
+                SearcherParser.parse("search c/google p/intern"));
+    }
+
+    @Test
+    void parse_emptyTerm_throws() {
+        assertThrows(JobPilotException.class, () ->
+                SearcherParser.parse("search s/"));
+    }
+}


### PR DESCRIPTION
fixes #280

Add validation so commands like 'search c/google p/intern' throw a clear format error, and add parser tests.
